### PR TITLE
Implement Scheme

### DIFF
--- a/basicAI.coffee
+++ b/basicAI.coffee
@@ -272,6 +272,7 @@ class BasicAI
     "Conspirator" if my.inPlay.length >= 2 or multiplier > 1
     "Familiar"
     "Highway"
+    "Scheme"
     "Wishing Well"
     "Great Hall" if state.cardInfo.Crossroads not in my.hand
     "Spice Merchant" if state.cardInfo.Copper in my.hand
@@ -455,6 +456,7 @@ class BasicAI
       "Crossroads" if (not my.crossroadsPlayed) or (my.actions > 0)
       "Torturer" if my.actions > 0 and state.countInSupply("Curse") >= 2
       "Young Witch" if my.actions > 0 and state.countInSupply("Curse") >= 2
+      "Scheme" if my.countInDeck("King's Court") >= 2
       "Scrying Pool"
       "Wharf" if my.actions > 0
       "Bridge" if my.actions > 0
@@ -880,6 +882,19 @@ class BasicAI
     gained = buyState.getSingleBuyDecision()
 
     return this.upgradeValue(state, [card, gained], my)
+
+  # Scheme uses the same priority function as multiplied actions.  Good actions
+  # to multiply this turn are typically good actions to have around next turn.
+  schemePriority: (state, my) ->
+    # Project a little of what the state will look like at the beginning of the
+    # next turn.  This keeps multipliedActionPriority from evaluating a card
+    # as though it will be used in the current (finished) turn.
+    myNext = {}
+    myNext[key] = value for key, value of my
+    myNext.actions = 1
+    myNext.buys = 1
+    myNext.coins = 0
+    this.multipliedActionPriority(state, myNext)
 
   # `scryingPoolDiscardValue` is like `discardValue`, except it strongly
   # prefers to discard non-actions.

--- a/cards.coffee
+++ b/cards.coffee
@@ -2210,6 +2210,19 @@ makeCard 'Salvager', action, {
       state.current.coins += coins
 }
 
+makeCard 'Scheme', action, {
+  cost: 3
+  actions: 1
+  cards: 1
+  cleanupEffect: (state) ->
+    choices = (card for card in state.current.inPlay when card.isAction)
+    choices.push(null)
+    choice = state.current.ai.choose('scheme', state, choices)
+    if choice isnt null
+      state.log("#{state.current.ai} uses Scheme to put #{choice} back on the deck.")
+      transferCardToTop(choice, state.current.inPlay, state.current.draw)
+}
+
 makeCard 'Scout', action, {
   cost: 4
   actions: +1

--- a/gameState.coffee
+++ b/gameState.coffee
@@ -897,6 +897,13 @@ class State
         @current.duration.push(card)
         @current.multipliedDurations.splice(i, 1)
 
+
+    # Handle effects of cleaning up the card, which may involve moving it
+    # somewhere else.  We do this before removing cards from play because
+    # cards such as Scheme and Herbalist need to consider cards in play.
+    cardsToCleanup = @current.inPlay.concat()
+    card.onCleanup(this) for card in cardsToCleanup
+
     # Clean up cards in play.
     while @current.inPlay.length > 0
       card = @current.inPlay[0]
@@ -907,9 +914,6 @@ class State
         @current.duration.push(card)
       else
         @current.discard.push(card)
-      # Handle effects of cleaning up the card, which may involve moving it
-      # somewhere else.
-      card.onCleanup(this)
 
     # Discard the remaining cards in hand.
     @current.discard = @current.discard.concat(@current.hand)

--- a/strategies/SchemeWitch.coffee
+++ b/strategies/SchemeWitch.coffee
@@ -1,0 +1,15 @@
+{
+  name: 'SchemeWitch'
+  requires: ['Witch', 'Scheme']
+  gainPriority: (state, my) -> [
+    "Colony" if my.countInDeck("Platinum") > 0
+    "Province" if state.countInSupply("Colony") <= 6 and my.countInDeck("Gold") > 0
+    "Witch" if my.countInDeck("Witch") == 0
+    "Duchy" if 0 < state.gainsToEndGame() <= 5
+    "Estate" if 0 < state.gainsToEndGame() <= 2
+    "Platinum"
+    "Gold"
+    "Scheme" if my.countInDeck('Scheme') < 2 and my.countInDeck('Silver') > 0
+    "Silver"
+  ]
+}


### PR DESCRIPTION
Fixes #37.  I implemented Scheme. I've included a sample Scheme-Witch strategy that's competitive with Double Witch.

In the process, I found an issue with the card clean-up code. Card#onCleanup was being called after the card was removed from play, and possibly after other cards had been removed from play. The problem is that some cards being cleaned up need to consider other cards that have been played. In the case of Scheme, it needs to consider itself as well. In theory, this could cause problems with Herbalist, too. I think Herbalist works coincidentally because, with the exception of Black Market, treasure is always played after actions.

I updated the cleanup code so that onCleanup is called first, then cards are removed from play. I didn't see any problems with existing cards, but I'd appreciate someone more familiar with the code taking a look at it.
