### PR TITLE
Fix Courtyard's choice of card to put back on deck

### DIFF
--- a/basicAI.coffee
+++ b/basicAI.coffee
@@ -631,7 +631,7 @@ class BasicAI
       for card in my.hand
         if (card.isTreasure) and (not (card in treasures))
           treasures.push card
-      treasures.sort( (x, y) -> x.coins - y.coins)
+      treasures.sort( (x, y) -> y.coins - x.coins)
 
       # Get the margin of how much money we're willing to discard.
       margin = my.ai.coinLossMargin(state)
@@ -1100,7 +1100,7 @@ class BasicAI
   # TODO: do we need an equivalent for potions?
   coinLossMargin: (state) ->
     newState = this.pessimisticBuyPhase(state)
-    coins = newState.coins
+    coins = newState.current.coins
     cardToBuy = newState.getSingleBuyDecision()
     return 0 if cardToBuy is null
     [coinsCost, potionsCost] = cardToBuy.getCost(newState)


### PR DESCRIPTION
There were two problems.  First, coinLossMargin was using State#coins rather than PlayerState#coins.  The former is undefined, so coinLossMargin was incorrectly returning 0.  Second, the treasure sorting in putOnDeckPriority was reversed, so the AI would put back the lowest valued treasure it could, rather than the highest.

These are now fixed.  Fixes #53.
