### PR TITLE
Mark Trader as a reaction card

### DIFF
--- a/cards.coffee
+++ b/cards.coffee
@@ -2455,6 +2455,7 @@ makeCard "Trade Route", action, {
 
 makeCard "Trader", action, {
   cost: 4
+  isReaction: true
   playEffect: (state) ->
     trashed = state.requireTrash(state.current, 1)[0]
     if trashed?


### PR DESCRIPTION
I was trying to implement a Trader/Cache strategy based on [this forum post](http://forum.dominionstrategy.com/index.php?topic=1740.0).  I noticed reactReplacingGain was never being called for Trader.  Tracking it down, it turns out Trader wasn't marked as a reaction card.
