### PR TITLE
Improve performance of checking whether a buy causes a loss

### DIFF
--- a/gameState.coffee
+++ b/gameState.coffee
@@ -669,11 +669,21 @@ class State
     total
     
   buyCausesToLose: (player, state, card) ->
-    if (state.gainsToEndGame() > 1)
+    if not card? || @supply[card] > 1 || state.gainsToEndGame() > 1
       return false
-    if (not card?)
+
+    # Check to see if the player would be in the lead after buying this card
+    maxOpponentScore = -Infinity
+    for status in this.getFinalStatus()
+      [name, score, turns] = status
+      if name == player.ai.toString()
+        myScore = score + card.getVP(player)
+      else if score > maxOpponentScore
+        maxOpponentScore = score
+
+    if myScore > maxOpponentScore
       return false
-    
+
     # One level of recursion is enough for first
     if (this.depth==0)
       [hypState, hypMy] = state.hypothetical(player.ai)


### PR DESCRIPTION
I was profiling other performance fixes when I noticed pull request #70 caused a big performance hit.  It nearly doubled the execution time of simulations.  The hypothetical game state portion of the logic is very expensive.  If there was one Province left in the supply, it would be run once per card the current player could afford, on average 70-75 times per game.

I added some early bail-out points: 1) it skips the check if the current buy won't empty a supply pile and 2) it skips the check if the current buy would leave the player in the lead.  Performance is pretty much back to what it was.  The expensive check is made only a couple of times per game and sometimes not at all.
