### PR TITLE
Typo in required cards (RoyalBigMoney strategy)

### DIFF
--- a/strategies/RoyalBigMoney.coffee
+++ b/strategies/RoyalBigMoney.coffee
@@ -1,6 +1,6 @@
 {
   name: 'Royal Big Money'
-  requires: ['Big Money']
+  requires: ['Royal Seal']
   gainPriority: (state, my) -> 
     if state.supply.Colony?
       [


### PR DESCRIPTION
Seems to require "Big Money" as a card. I assume it's a typo and should be "Royal Seal".
