### PR TITLE
Fixed trashing bug, Lookout bug. Added Forager

### DIFF
--- a/basicAI.coffee
+++ b/basicAI.coffee
@@ -1,5 +1,7 @@
 {c} = require './cards' if exports?
 
+Array::remove = (e) -> @[t..t] = [] if (t = @indexOf(e)) > -1
+
 # The Basic AI
 # ------------
 # This class defines a rule-based AI of the kind that is popular
@@ -100,7 +102,7 @@ class BasicAI
       if value > bestValue
         bestValue = value
         bestChoice = choice
-      
+
     # If we got a valid choice, return it.
     if bestChoice in choices
       return bestChoice
@@ -1149,10 +1151,20 @@ class BasicAI
 
   # `wantsToTrash` returns the number of cards in hand that we would trash
   # for no benefit.
-  wantsToTrash: (state) ->
+  # `skipCardName let you specify a card to ignore. In general
+  # this will be the card causing the trashing in the first place, and is
+  # needed in ai_playValue (since the card has not been played yet) but
+  # not in playEffect (where the card will no longer be in the bot's hand)
+  wantsToTrash: (state, skipCardName=null) ->
     my = this.myPlayer(state)
     trashableCards = 0
-    for card in my.hand
+    if skipCardName?
+      adjusted_hand = my.hand.slice 0
+      adjusted_hand.remove(c[skipCardName])
+    else
+      adjust_hand = my.hand # No need to copy
+
+    for card in adjusted_hand
       if this.chooseTrash(state, [card, null]) is card
         trashableCards += 1
     return trashableCards

--- a/cards.coffee
+++ b/cards.coffee
@@ -1021,7 +1021,7 @@ makeCard 'Upgrade', c.Remodel, {
 
   ai_playValue: (state, my) ->
     multiplier = my.getMultiplier()
-    wantsToTrash = my.ai.wantsToTrash(state)
+    wantsToTrash = my.ai.wantsToTrash(state, 'Upgrade')
     if wantsToTrash >= multiplier
       490
     else
@@ -1045,7 +1045,7 @@ makeCard 'Remake', c.Remodel, {
 
   ai_playValue: (state, my) ->
     multiplier = my.getMultiplier()
-    wantsToTrash = my.ai.wantsToTrash(state)
+    wantsToTrash = my.ai.wantsToTrash(state, "Remake")
     if wantsToTrash >= multiplier*2
       178
     else
@@ -1191,13 +1191,13 @@ makeCard 'Ambassador', attack, {
         state.log("...but #{cardName} is not in the Supply.")
 
   ai_playValue: (state, my) ->
-    wantsToTrash = my.ai.wantsToTrash(state)
+    wantsToTrash = my.ai.wantsToTrash(state, "Ambassador")
     if wantsToTrash > 0
       150
     else
       -20
   ai_multipliedValue: (state, my) ->
-    wantsToTrash = my.ai.wantsToTrash(state)
+    wantsToTrash = my.ai.wantsToTrash(state, "Ambassador")
     if my.actions > 0 and wantsToTrash > 0
       1100
     else
@@ -2079,7 +2079,7 @@ makeCard 'Chapel', action, {
       state.allowTrash(state.current, 4)
 
   ai_playValue: (state, my) ->
-    wantsToTrash = my.ai.wantsToTrash(state)
+    wantsToTrash = my.ai.wantsToTrash(state, "Chapel")
     if wantsToTrash > 0
       146
     else
@@ -2769,7 +2769,7 @@ makeCard "Lookout", action, {
     state.current.setAside = []
 
   ai_playValue: (state, my) ->
-    if state.gainsToEndGame >= 5 or state.cardInfo.Curse in my.draw
+    if state.gainsToEndGame() >= 5 or state.cardInfo.Curse in my.draw
       895
     else
       -5
@@ -2892,7 +2892,7 @@ makeCard "Mint", action, {
 
   ai_playValue: (state, my) ->
     multiplier = my.getMultiplier()
-    wantsToTrash = my.ai.wantsToTrash(state)
+    wantsToTrash = my.ai.wantsToTrash(state) # Does this statement have any effect?
     if my.ai.choose('mint', state, my.hand)
       140
     else
@@ -3414,7 +3414,7 @@ makeCard "Trade Route", action, {
 
   ai_playValue: (state, my) ->
     multiplier = my.getMultiplier()
-    wantsToTrash = my.ai.wantsToTrash(state)
+    wantsToTrash = my.ai.wantsToTrash(state, "Trade Route")
     if wantsToTrash >= multiplier
       160
     else
@@ -3439,7 +3439,7 @@ makeCard "Trader", action, {
 
   ai_playValue: (state, my) ->
     multiplier = my.getMultiplier()
-    wantsToTrash = my.ai.wantsToTrash(state)
+    wantsToTrash = my.ai.wantsToTrash(state, "Trader")
     if wantsToTrash >= multiplier
       142
     else
@@ -3455,7 +3455,7 @@ makeCard "Trading Post", action, {
 
   ai_playValue: (state, my) ->
     multiplier = my.getMultiplier()
-    wantsToTrash = my.ai.wantsToTrash(state)
+    wantsToTrash = my.ai.wantsToTrash(state, "Trading Post")
     if wantsToTrash >= multiplier*2
       148
     else
@@ -3480,8 +3480,8 @@ makeCard "Transmute", action, {
 
   ai_playValue: (state, my) ->
     multiplier = my.getMultiplier()
-    wantsToTrash = my.ai.wantsToTrash(state)
-    if my.ai.choose('mint', state, my.hand)
+    wantsToTrash = my.ai.wantsToTrash(state) # Does this statement have any effect?
+    if my.ai.choose('mint', state, my.hand) # What is 'mint' doing here?
       106
     else
       -27
@@ -3696,6 +3696,25 @@ makeCard 'Workshop', action, {
     state.gainOneOf(state.current, choices)
 
   ai_playValue: (state, my) -> 112
+}
+
+makeCard 'Forager', action, {
+  cost: 3
+  buys: 1
+  actions: 1
+
+  playEffect: (state) ->
+    state.requireTrash(state.current, 1)
+    state.current.coins += Set(card for card in state.trash\
+        when card.isTreasure).size
+
+  ai_playValue: (state, my) ->
+    multiplier = my.getMultiplier()
+    wantsToTrash = my.ai.wantsToTrash(state, 'Forager')
+    if wantsToTrash >= multiplier
+      489 # One less than Upgrade
+    else
+      -25
 }
 
 # Utility functions


### PR DESCRIPTION
- Added Forager
- Fixed [Lookout bug](http://forum.dominionstrategy.com/index.php?topic=619.msg486204#msg486204)
- Fixed trashing bug that affected Forager, Trade Route, and other cards

The trashing bug was this: say you included Trade Route on in trashPriority. Imagine you drew a hand with only one Trade Route in it and no other cards you wanted to trash. When the simulator called ai_playValue for Trade Route, ai_playValue would say, "Hey, there's a card in my hand I want to trash (Trade Route), so go ahead and play me." So the bot would play the Trade Route, but at that point there's nothing left in the bot's hand that it wants to trash: Trade Route was the only card in the hand that the bot wanted to trash. So the bot would be stuck trashing some other card it would have rather hung on to. I've pasted a simple bot that demonstrates the bug below.

I am new to Dominiate, Coffeescript, and GitHub, but I think I did everything right. However, I was unsure where to put the line `Array::remove = (e) -> @[t..t] = [] if (t = @indexOf(e)) > -1` in basicAI.coffee, so I put it on top. Also, I decided to give Forager ai_playValue one below Upgrade, but am unsure of that as well.

```
{
  name: 'TradeRouteBug'
  requires: ["Trade Route"]
  gainPriority: (state, my) -> [
    "Trade Route" if my.countInDeck("Trade Route") == 0
  ]

  trashPriority: (state, my) -> [
    "Trade Route"
  ]

  trashValue: (state, card, my) -> [
    # Without this Copper and Curse will get trashed even if they're not
    # in trashPriority
    -1
  ]
}
```
